### PR TITLE
Some extensions to Generator for KSQL performance tests

### DIFF
--- a/src/test/java/io/confluent/avro/random/generator/AlwaysIncludeOptionalsTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/AlwaysIncludeOptionalsTest.java
@@ -1,0 +1,21 @@
+package io.confluent.avro.random.generator;
+
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class AlwaysIncludeOptionalsTest {
+  final Random RNG = new Random();
+  final String SCHEMA = "[\"null\", \"string\"]";
+  final int ITERATIONS = 100;
+
+  @Test
+  public void shouldAlwaysGenerateOptional() {
+    final Generator generator = new Generator(SCHEMA, RNG, true);
+    IntStream.range(0, ITERATIONS).forEach(i -> assertThat(generator.generate(), notNullValue()));
+  }
+}

--- a/src/test/resources/test-schemas/domain.json
+++ b/src/test/resources/test-schemas/domain.json
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "domain_test",
+  "fields":
+  [
+    {
+      "name": "domain_property",
+      "type":
+      {
+        "type": "string",
+        "arg.properties": {
+          "length": 32,
+          "domain": 100
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Add a domain property for strings that restricts the possible
  values to a set of the given size.
- Add a parameter alwaysIncludeOptionals that tells the generator
  to always generate a value for optional fields.
- Use ThreadLocalRandom when generating strings.