### PR TITLE
Fix the build by update gradle wrapper version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip


### PR DESCRIPTION
Build is failing:
$ ./gradlew standalone

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine java version from '11'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

=> Should be fixed by updating gradle wrapper version
(https://github.com/openrndr/openrndr/pull/23)