### PR TITLE
Make generator caches non-static.

### DIFF
--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -59,9 +59,9 @@ import java.util.Random;
 @SuppressWarnings("WeakerAccess")
 public class Generator {
 
-  private static final Map<Schema, Generex> generexCache = new HashMap<>();
-  private static final Map<Schema, List<Object>> optionsCache = new HashMap<>();
-  private static final Map<Schema, Iterator<Object>> iteratorCache = new IdentityHashMap<>();
+  private final Map<Schema, Generex> generexCache = new HashMap<>();
+  private final Map<Schema, List<Object>> optionsCache = new HashMap<>();
+  private final Map<Schema, Iterator<Object>> iteratorCache = new IdentityHashMap<>();
 
   /**
    * The name to use for the top-level JSON property when specifying ARG-specific attributes.

--- a/src/test/java/io/confluent/avro/random/generator/IterationTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/IterationTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.avro.random.generator.util.ResourceUtil;
+import java.util.stream.IntStream;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,5 +52,14 @@ public class IterationTest {
   public void shouldSupportPrefixAndSuffix() {
     final GenericRecord generated = (GenericRecord) generator.generate();
     assertThat(generated.get("prefixed_suffixed_string_iteration"), is("pre-0-post"));
+  }
+
+  @Test
+  public void shouldGenerateFromSameSchemaOnMultipleThreads() {
+    IntStream.range(0, 10).parallel()
+        .forEach(idx -> {
+          final Generator generator = new Generator(ITERATION_SCHEMA, new Random());
+          generator.generate();
+        });
   }
 }


### PR DESCRIPTION
Currently, because `Generator`'s `iteratorCache` is a static `IdentityHashMap` (which isn't thread safe), when multiple threads each create their own `Generator` instance using the same `Schema` object and try to generate data simultaneously, a NullPointerException is thrown when a race is encountered:
```
Caused by: java.lang.NullPointerException
	at io.confluent.avro.random.generator.Generator.generateIteration(Generator.java:943)
	at io.confluent.avro.random.generator.Generator.generateObject(Generator.java:304)
	at io.confluent.avro.random.generator.Generator.generateRecord(Generator.java:1135)
	at io.confluent.avro.random.generator.Generator.generateObject(Generator.java:330)
	at io.confluent.avro.random.generator.Generator.generateRecord(Generator.java:1135)
	at io.confluent.avro.random.generator.Generator.generateObject(Generator.java:330)
	at io.confluent.avro.random.generator.Generator.generate(Generator.java:295)
```
This PR fixes this by changing `iteratorCache` to be non-static. Similar changes are made to `generexCache` and `optionsCache`.