### PR TITLE
Fix how float ranges are validated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ bin/
 *.iml
 *.iws
 *.ipr
+out/
 
 .DS_STORE

--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -1277,7 +1277,7 @@ public class Generator {
 
   private Float getFloatNumberField(String property, String field, Map propsMap) {
     Double result = getDecimalNumberField(property, field, propsMap);
-    if (result != null && (result > Float.MAX_VALUE || result < -1 * Float.MIN_VALUE)) {
+    if (result != null && (result > Float.MAX_VALUE || result < -1 * Float.MAX_VALUE)) {
       throw new RuntimeException(String.format(
           "'%s' field of %s property must be a valid float for float schemas",
           field,

--- a/src/test/resources/test-schemas/ranges.json
+++ b/src/test/resources/test-schemas/ranges.json
@@ -1,0 +1,43 @@
+{ "type": "record",
+  "name": "ranges",
+  "namespace": "io.confluent.avro.random.generator",
+  "fields":
+    [
+      {
+        "name": "int_range",
+        "type": {
+          "type": "int",
+          "arg.properties": {
+            "range": {
+              "min": -10,
+              "max": 10
+            }
+          }
+        }
+      },
+      {
+        "name": "float_range",
+        "type": {
+          "type": "float",
+          "arg.properties": {
+            "range": {
+              "min": -10.0,
+              "max": 10.0
+            }
+          }
+        }
+      },
+      {
+        "name": "double_range",
+        "type": {
+          "type": "double",
+          "arg.properties": {
+            "range": {
+              "min": -10.0,
+              "max": 10.0
+            }
+          }
+        }
+      }
+    ]
+}


### PR DESCRIPTION
Use `-Float.MaxValue` to validate the lower bound of ranges for `Float` fields. Currently, `Float.MinValue` is used but that's not the lowest negative value but the smallest positive representable value.

Also, add a test schema that makes tests fail unless you fix this check.