### PR TITLE
CC-7063: Bump Avro version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ artifacts {
 dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
 
-    compile group: 'org.apache.avro', name: 'avro', version: '1.8.1'
+    compile group: 'org.apache.avro', name: 'avro', version: '1.9.1'
 
     compile group: 'com.github.mifmif', name: 'generex', version: '1.0.1'
 

--- a/src/test/java/io/confluent/avro/random/generator/IterationTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/IterationTest.java
@@ -4,12 +4,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.avro.random.generator.util.ResourceUtil;
-import java.util.stream.IntStream;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Random;
+import java.util.stream.IntStream;
 
 
 public class IterationTest {


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-7063)

Title says it all; the main changes here bump the Avro dependency version from 1.8.1 to 1.9.1. There's also some import re-ordering in a test class to silence Checkstyle errors.