### PR TITLE
MINOR: Generate regex-based strings deterministically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ dependencies {
 
     compile group: 'org.apache.avro', name: 'avro', version: '1.9.1'
 
-    compile group: 'com.github.mifmif', name: 'generex', version: '1.0.1'
+    compile group: 'com.github.mifmif', name: 'generex', version: '1.0.2'
 
     ////////////////////////////////////////////////////////////////
 

--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -1143,7 +1143,7 @@ public class Generator {
       if (!(regexProp instanceof String)) {
         throw new RuntimeException(String.format("%s property must be a string", REGEX_PROP));
       }
-      generexCache.put(schema, new Generex((String) regexProp));
+      generexCache.put(schema, new Generex((String) regexProp, random));
     }
     // Generex.random(low, high) generates in range [low, high]; we want [low, high), so subtract
     // 1 from maxLength

--- a/src/test/java/io/confluent/avro/random/generator/GeneratorTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/GeneratorTest.java
@@ -1,6 +1,7 @@
 package io.confluent.avro.random.generator;
 
 import static io.confluent.avro.random.generator.util.ResourceUtil.loadContent;
+import static junit.framework.TestCase.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,5 +64,14 @@ public class GeneratorTest {
     } catch (final IOException ioe) {
       throw new RuntimeException("failed to find test schemas", ioe);
     }
+  }
+
+  @Test
+  public void shouldGenerateValuesDeterministically() {
+    long seed = 100L;
+    Generator generatorA = new Generator(content, new Random(seed));
+    Generator generatorB = new Generator(content, new Random(seed));
+    assertEquals(generatorA.generate(), generatorB.generate());
+    assertEquals(generatorA.generate(), generatorB.generate());
   }
 }


### PR DESCRIPTION
This required a version bump, to pull in this feature in Generex: https://github.com/mifmif/Generex/pull/27/files

Signed-off-by: Greg Harris <gregh@confluent.io>