### PR TITLE
CC-7198: Make iterators reentrant

### DIFF
--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -1454,10 +1454,10 @@ public class Generator {
 
     @Override
     public Object next() {
+      BigDecimal result = current.add(start);
       current = current
           .add(step)
           .divideAndRemainder(modulo)[1];
-      BigDecimal result = current.add(start);
       switch (type) {
         case FLOAT:
           return result.floatValue();

--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -622,8 +622,7 @@ public class Generator {
 
     // If an odd number of records have been generated previously, then the boolean will have
     // changed state effectively once, and so the start state should be inverted.
-    startProp = (generation % 2 == 1) ^ ((Boolean) startProp);
-    return new BooleanIterator((Boolean) startProp);
+    return new BooleanIterator((generation % 2 == 1) ^ ((Boolean) startProp));
   }
 
   private Iterator<Object> getIntegralIterator(

--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -188,7 +188,7 @@ public class Generator {
 
   private final Schema topLevelSchema;
   private final Random random;
-  private final long count;
+  private final long generation;
 
   /**
    * Creates a generator out of an already-parsed {@link Schema}.
@@ -199,10 +199,10 @@ public class Generator {
     this(topLevelSchema, random, 0L);
   }
 
-  public Generator(Schema topLevelSchema, Random random, long count) {
+  public Generator(Schema topLevelSchema, Random random, long generation) {
     this.topLevelSchema = topLevelSchema;
     this.random = random;
-    this.count = count;
+    this.generation = generation;
   }
 
   /**
@@ -582,7 +582,7 @@ public class Generator {
 
     // If an odd number of records have been generated previously, then the boolean will have
     // changed state effectively once, and so the start state should be inverted.
-    startProp = (count % 2 == 1) ^ ((Boolean) startProp);
+    startProp = (generation % 2 == 1) ^ ((Boolean) startProp);
     return new BooleanIterator((Boolean) startProp);
   }
 
@@ -694,7 +694,7 @@ public class Generator {
         iterationStart,
         iterationRestart,
         iterationStep,
-        count,
+        generation,
         type
     );
   }
@@ -807,7 +807,7 @@ public class Generator {
         iterationStart,
         iterationRestart,
         iterationStep,
-        count,
+        generation,
         type
     );
   }

--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -1481,7 +1481,7 @@ public class Generator {
       if (count > 0) {
         current = BigDecimal.valueOf(count)
             .multiply(this.step)
-            .divideAndRemainder(this.modulo)[1];
+            .remainder(this.modulo);
       }
     }
 
@@ -1490,7 +1490,7 @@ public class Generator {
       BigDecimal result = current.add(start);
       current = current
           .add(step)
-          .divideAndRemainder(modulo)[1];
+          .remainder(modulo);
       switch (type) {
         case FLOAT:
           return result.floatValue();

--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -195,11 +195,12 @@ public class Generator {
    * @param topLevelSchema The schema to generate values for.
    * @param random The object to use for generating randomness when producing values.
    */
+  @Deprecated
   public Generator(Schema topLevelSchema, Random random) {
     this(topLevelSchema, random, 0L);
   }
 
-  public Generator(Schema topLevelSchema, Random random, long generation) {
+  protected Generator(Schema topLevelSchema, Random random, long generation) {
     this.topLevelSchema = topLevelSchema;
     this.random = random;
     this.generation = generation;
@@ -210,12 +211,9 @@ public class Generator {
    * @param schemaString An Avro Schema represented as a string.
    * @param random The object to use for generating randomness when producing values.
    */
+  @Deprecated
   public Generator(String schemaString, Random random) {
-    this(schemaString, random, 0L);
-  }
-
-  public Generator(String schemaString, Random random, long count) {
-    this(new Schema.Parser().parse(schemaString), random, count);
+    this(new Schema.Parser().parse(schemaString), random);
   }
 
   /**
@@ -224,12 +222,9 @@ public class Generator {
    * @param random The object to use for generating randomness when producing values.
    * @throws IOException if an error occurs while reading from the input stream.
    */
+  @Deprecated
   public Generator(InputStream schemaStream, Random random) throws IOException {
-    this(schemaStream, random, 0L);
-  }
-
-  public Generator(InputStream schemaStream, Random random, long count) throws IOException {
-    this(new Schema.Parser().parse(schemaStream), random, count);
+    this(new Schema.Parser().parse(schemaStream), random);
   }
 
   /**
@@ -238,12 +233,57 @@ public class Generator {
    * @param random The object to use for generating randomness when producing values.
    * @throws IOException if an error occurs while reading from the schema file.
    */
+  @Deprecated
   public Generator(File schemaFile, Random random) throws IOException {
-    this(schemaFile, random, 0L);
+    this(new Schema.Parser().parse(schemaFile), random);
   }
 
-  public Generator(File schemaFile, Random random, long count) throws IOException {
-    this(new Schema.Parser().parse(schemaFile), random, count);
+  public static class Builder {
+
+    private Schema topLevelSchema;
+    private Random random;
+    private long generation;
+    private Schema.Parser parser;
+
+    public Builder() {
+      parser = new Schema.Parser();
+      random = new Random();
+      generation = 0L;
+    }
+
+    public Builder schema(Schema schema) {
+      topLevelSchema = schema;
+      return this;
+    }
+
+    public Builder schemaFile(File schemaFile) throws IOException {
+      topLevelSchema = parser.parse(schemaFile);
+      return this;
+    }
+
+    public Builder schemaStream(InputStream schemaStream) throws IOException {
+      topLevelSchema = parser.parse(schemaStream);
+      return this;
+    }
+
+    public Builder schemaString(String schemaString) {
+      topLevelSchema = parser.parse(schemaString);
+      return this;
+    }
+
+    public Builder random(Random random) {
+      this.random = random;
+      return this;
+    }
+
+    public Builder generation(long generation) {
+      this.generation = generation;
+      return this;
+    }
+
+    public Generator build() {
+      return new Generator(topLevelSchema, random, generation);
+    }
   }
 
   /**

--- a/src/main/java/io/confluent/avro/random/generator/Main.java
+++ b/src/main/java/io/confluent/avro/random/generator/Main.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.Random;
 
 /* TODO:  Find a good argument parser that doesn't strip double quotes off of arguments and allows
           for mutually exclusive options to cancel each other out without error */
@@ -301,14 +300,13 @@ public class Main {
   }
 
   private static Generator getGenerator(String schema, String schemaFile) throws IOException {
-    Random random = new Random();
     if (schema != null) {
-      return new Generator(schema, random);
+      return new Generator.Builder().schemaString(schema).build();
     } else if (!schemaFile.equals("-")) {
-      return new Generator(new File(schemaFile), random);
+      return new Generator.Builder().schemaFile(new File(schemaFile)).build();
     } else {
       System.err.println("Reading schema from stdin...");
-      return new Generator(System.in, random);
+      return new Generator.Builder().schemaStream(System.in).build();
     }
   }
 

--- a/src/test/java/io/confluent/avro/random/generator/GeneratorTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/GeneratorTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 public class GeneratorTest {
 
   private static final String SCHEMA_TEST_DIR = "test-schemas";
-  private static final Random RNG = new Random();
   private final String fileName;
   private final String content;
 
@@ -45,7 +44,9 @@ public class GeneratorTest {
 
   @Test
   public void shouldHandleSchema() {
-    final Generator generator = new Generator(content, RNG);
+    final Generator generator = new Generator.Builder()
+        .schemaString(content)
+        .build();
     final Object generated = generator.generate();
     System.out.println(fileName + ": " + generated);
   }
@@ -69,8 +70,14 @@ public class GeneratorTest {
   @Test
   public void shouldGenerateValuesDeterministically() {
     long seed = 100L;
-    Generator generatorA = new Generator(content, new Random(seed));
-    Generator generatorB = new Generator(content, new Random(seed));
+    Generator generatorA = new Generator.Builder()
+        .schemaString(content)
+        .random(new Random(seed))
+        .build();
+    Generator generatorB = new Generator.Builder()
+        .schemaString(content)
+        .random(new Random(seed))
+        .build();
     assertEquals(generatorA.generate(), generatorB.generate());
     assertEquals(generatorA.generate(), generatorB.generate());
   }

--- a/src/test/java/io/confluent/avro/random/generator/IterationTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/IterationTest.java
@@ -8,13 +8,11 @@ import org.apache.avro.generic.GenericRecord;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Random;
 import java.util.stream.IntStream;
 
 
 public class IterationTest {
 
-  private static final Random RNG = new Random();
   private static final String ITERATION_SCHEMA =
       ResourceUtil.loadContent("test-schemas/iteration.json");
 
@@ -22,7 +20,7 @@ public class IterationTest {
 
   @Before
   public void setUp() {
-    generator = new Generator(ITERATION_SCHEMA, RNG);
+    generator = new Generator.Builder().schemaString(ITERATION_SCHEMA).build();
   }
 
   @Test
@@ -58,7 +56,7 @@ public class IterationTest {
   public void shouldGenerateFromSameSchemaOnMultipleThreads() {
     IntStream.range(0, 10).parallel()
         .forEach(idx -> {
-          final Generator generator = new Generator(ITERATION_SCHEMA, new Random());
+          final Generator generator = new Generator.Builder().schemaString(ITERATION_SCHEMA).build();
           generator.generate();
         });
   }
@@ -66,7 +64,10 @@ public class IterationTest {
   @Test
   public void shouldSimulatePreviousIterations() {
     for (long i = 0; i < 1e3; i++) {
-      Generator simulation = new Generator(ITERATION_SCHEMA, RNG, i);
+      Generator simulation = new Generator.Builder()
+          .schemaString(ITERATION_SCHEMA)
+          .generation(i)
+          .build();
       assertThat("Different on iteration " + i, simulation.generate(), is(generator.generate()));
     }
   }

--- a/src/test/java/io/confluent/avro/random/generator/IterationTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/IterationTest.java
@@ -63,7 +63,7 @@ public class IterationTest {
 
   @Test
   public void shouldSimulatePreviousIterations() {
-    for (long i = 0; i < 1e3; i++) {
+    for (long i = 0; i < 1000; i++) {
       Generator simulation = new Generator.Builder()
           .schemaString(ITERATION_SCHEMA)
           .generation(i)

--- a/src/test/java/io/confluent/avro/random/generator/IterationTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/IterationTest.java
@@ -62,4 +62,12 @@ public class IterationTest {
           generator.generate();
         });
   }
+
+  @Test
+  public void shouldSimulatePreviousIterations() {
+    for (long i = 0; i < 1e3; i++) {
+      Generator simulation = new Generator(ITERATION_SCHEMA, RNG, i);
+      assertThat("Different on iteration " + i, simulation.generate(), is(generator.generate()));
+    }
+  }
 }


### PR DESCRIPTION
It is desirable to have the Avro Random Generator initialize it's iterators at values other than the `start` value specified in the iterator properties. This PR adds constructors to provide the Generator object with a `count`, which is the number of generations that have appeared previously.

The numeric iterators cope with this by simulating the previous iterations with multiplication.
Because repeated addition is not the same as multiplication, it is necessary to use `BigDecimal` to perform the double and float calculations.

Signed-off-by: Greg Harris <gregh@confluent.io>