### PR TITLE
CC-7198: Add iterator initializer schema field

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,19 @@ read from the file after decoding with the specified format (currently
 "json" and "binary" are the only supported values, and "binary" may be
 somewhat buggy).
 + __iteration:__ A JSON object that conforms to the following format:
-`{"start": <start>, "restart": <restart>, "step": <step>}` ("start" has
-to be specified, but "restart" and "step" do not). If provided with a
+`{"start": <start>, "restart": <restart>, "step": <step>, "initial": 
+<initial> }` ("start" has to be specified, but "restart", "step", 
+and "initial" do not). If provided with a
 numeric schema, ensures that the first generated value will be equal to
-&lt;start&gt;, and successive values will increase by &lt;step&gt;,
-wrapping around at &lt;restart&gt;; &lt;step&gt; will default to 1 if
-&lt;restart&gt; is greater than &lt;step&gt;, will default to -1 if
-&lt;restart&gt; is less than &lt;step&gt;, and an error will be thrown
-if &lt;restart&gt; is equal to &lt;step&gt;. If provided with a boolean
+&lt;initial&gt; (or &lt;start&gt; if &lt;initial&gt; is not specified),
+and successive values will increase by &lt;step&gt;, wrapping around at 
+&lt;restart&gt; back to &lt;start&gt;; &lt;step&gt; will default to 1 if
+&lt;restart&gt; is greater than &lt;start&gt;, will default to -1 if
+&lt;restart&gt; is less than &lt;start&gt;, and an error will be thrown
+if &lt;restart&gt; is equal to &lt;start&gt;. If provided with a boolean
 schema, only &lt;start&gt; may be specified; the resulting values will
 begin with &lt;start&gt; and alternate from `true` to `false` and from
-`false` to `true` from that point on.
+`false` to `true` from that point on. 
 + __range:__ A JSON object that conforms to the following format:
 `{"min": <min>, "max": <max>}` (at least one of "min" or "max" must be
 specified). If provided, ensures that the generated number will be

--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -566,19 +566,7 @@ public class Generator {
           ITERATION_PROP_STEP
       ));
     }
-    Object initialProp = startProp;
-    if (iterationProps.containsKey(ITERATION_PROP_INITIAL)) {
-      initialProp = iterationProps.get(ITERATION_PROP_INITIAL);
-      if (!(initialProp instanceof Boolean)) {
-        throw new RuntimeException(String.format(
-            "%s field of %s property for a boolean schema must be a boolean, was %s instead",
-            ITERATION_PROP_INITIAL,
-            ITERATION_PROP,
-            initialProp.getClass().getName()
-        ));
-      }
-    }
-    return new BooleanIterator((Boolean) initialProp);
+    return new BooleanIterator((Boolean) startProp);
   }
 
   private Iterator<Object> getIntegralIterator(

--- a/src/test/java/io/confluent/avro/random/generator/IterationTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/IterationTest.java
@@ -38,6 +38,16 @@ public class IterationTest {
   }
 
   @Test
+  public void shouldBeginIterationAtInitialValue() {
+    final GenericRecord generated = (GenericRecord) generator.generate();
+    assertThat(generated.get("boolean_iteration_offset"), is(true));
+    assertThat(generated.get("int_iteration_offset"), is(40));
+    assertThat(generated.get("long_iteration_offset"), is(0L));
+    assertThat(generated.get("float_iteration_offset"), is(0.0f));
+    assertThat(generated.get("double_iteration_offset"), is(5.0));
+  }
+
+  @Test
   public void shouldSupportStringIteration() {
     final GenericRecord first = (GenericRecord) generator.generate();
     final GenericRecord second = (GenericRecord) generator.generate();

--- a/src/test/java/io/confluent/avro/random/generator/IterationTest.java
+++ b/src/test/java/io/confluent/avro/random/generator/IterationTest.java
@@ -40,7 +40,6 @@ public class IterationTest {
   @Test
   public void shouldBeginIterationAtInitialValue() {
     final GenericRecord generated = (GenericRecord) generator.generate();
-    assertThat(generated.get("boolean_iteration_offset"), is(true));
     assertThat(generated.get("int_iteration_offset"), is(40));
     assertThat(generated.get("long_iteration_offset"), is(0L));
     assertThat(generated.get("float_iteration_offset"), is(0.0f));

--- a/src/test/resources/test-schemas/iteration.json
+++ b/src/test/resources/test-schemas/iteration.json
@@ -15,6 +15,18 @@
         }
       },
       {
+        "name": "boolean_iteration_offset",
+        "type": {
+          "type": "boolean",
+          "arg.properties": {
+            "iteration": {
+              "start": false,
+              "initial": true
+            }
+          }
+        }
+      },
+      {
         "name": "int_iteration",
         "type": {
           "type": "int",
@@ -22,6 +34,19 @@
             "iteration": {
               "start": 50,
               "restart": -10
+            }
+          }
+        }
+      },
+      {
+        "name": "int_iteration_offset",
+        "type": {
+          "type": "int",
+          "arg.properties": {
+            "iteration": {
+              "start": 50,
+              "restart": -10,
+              "initial": 40
             }
           }
         }
@@ -40,6 +65,20 @@
         }
       },
       {
+        "name": "long_iteration_offset",
+        "type": {
+          "type": "long",
+          "arg.properties": {
+            "iteration": {
+              "start": -50,
+              "restart": 100,
+              "step": 47,
+              "initial": 0
+            }
+          }
+        }
+      },
+      {
         "name": "float_iteration",
         "type": {
           "type":"float",
@@ -47,6 +86,19 @@
             "iteration": {
               "start": 10.4,
               "step": 5.1
+            }
+          }
+        }
+      },
+      {
+        "name": "float_iteration_offset",
+        "type": {
+          "type":"float",
+          "arg.properties": {
+            "iteration": {
+              "start": 10.4,
+              "step": 5.1,
+              "initial": 0
             }
           }
         }
@@ -60,6 +112,20 @@
               "start": 0.0,
               "restart": 10.0,
               "step": 27.3
+            }
+          }
+        }
+      },
+      {
+        "name": "double_iteration_offset",
+        "type": {
+          "type": "double",
+          "arg.properties": {
+            "iteration": {
+              "start": 0.0,
+              "restart": 10.0,
+              "step": 27.3,
+              "initial": 5.0
             }
           }
         }

--- a/src/test/resources/test-schemas/iteration.json
+++ b/src/test/resources/test-schemas/iteration.json
@@ -15,18 +15,6 @@
         }
       },
       {
-        "name": "boolean_iteration_offset",
-        "type": {
-          "type": "boolean",
-          "arg.properties": {
-            "iteration": {
-              "start": false,
-              "initial": true
-            }
-          }
-        }
-      },
-      {
         "name": "int_iteration",
         "type": {
           "type": "int",


### PR DESCRIPTION
Similar to #14, but implements a much more general feature that can still be leveraged to provide the same functionality.

This allows for users to set an initial value for iterators that is different than the bottom of the wrap-around range for the value.

For example, this allows the creation of the sequence: `[0, 1, 2, -2, -1, 0, 1, 2, -2, ...]`. with start = -2, end = 3, initial = 0.
