### PR TITLE
Fix annotations not respected on keys annotation

### DIFF
--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -1287,10 +1287,9 @@ public class Generator {
           result.put(generateOption(schema, keyPropMap), generateObject(schema.getValueType()));
         }
       } else {
-        int keyLength = getLengthBounds(keyPropMap.get(LENGTH_PROP)).random();
         for (int i = 0; i < length; i++) {
           result.put(
-              generateRandomString(keyLength),
+              generateString(schema, keyPropMap),
               generateObject(schema.getValueType())
           );
         }


### PR DESCRIPTION
Currently, no other annotations are respected on the `keys` annotation itself, except for `length` and `options`. But accordingly to the documentation all annotations except for `odds` should be working.

This PR fixes this, now all annotations should be working.