### PR TITLE
fix Issue #27: parse array options with appropriate type

### DIFF
--- a/src/main/java/io/confluent/avro/random/generator/Generator.java
+++ b/src/main/java/io/confluent/avro/random/generator/Generator.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 /**
  * Generates Java objects according to an {@link Schema Avro Schema}.
@@ -463,7 +464,11 @@ public class Generator {
     } else if (schema.getType() == Schema.Type.LONG && option instanceof Integer) {
       option = ((Integer) option).longValue();
     } else if (schema.getType() == Schema.Type.ARRAY && option instanceof Collection) {
-      option = new GenericData.Array(schema, (Collection) option);
+      Collection<Object> optionItems = (Collection) option;
+      List<Object> wrappedOptions = optionItems.stream()
+          .map(item -> wrapOption(schema.getElementType(), item))
+          .collect(Collectors.toList());
+      option = new GenericData.Array(schema, wrappedOptions);
     } else if (schema.getType() == Schema.Type.ENUM && option instanceof String) {
       option = new GenericData.EnumSymbol(schema, (String) option);
     } else if (schema.getType() == Schema.Type.FIXED && option instanceof String) {

--- a/src/test/resources/test-schemas/array-option.json
+++ b/src/test/resources/test-schemas/array-option.json
@@ -1,0 +1,10 @@
+{
+  "type": "array",
+  "items": "long",
+  "arg.properties": {
+    "options": [
+      [ 1, 2 ],
+      [ 3, 4 ]
+    ]
+  }
+}


### PR DESCRIPTION
Hello,

This update allows using whole array options for any type, not only int and string. 
Tested for long and record types. 

Fix for Issue #27 